### PR TITLE
feat(admin/logs): add pagination support for log retrieval

### DIFF
--- a/swagger_specs/logs_get.yaml
+++ b/swagger_specs/logs_get.yaml
@@ -1,13 +1,25 @@
 tags:
   - "admin"
-summary: "Retrieve all logs"
-description: "This endpoint allows an admin to retrieve all system logs."
+summary: "Retrieve all logs with pagination"
+description: "This endpoint allows an admin to retrieve all system logs with pagination."
 parameters:
   - name: "admin-key"
     in: "header"
     required: true
     type: "string"
     description: "The admin key to authenticate the request."
+  - name: "X-Page"
+    in: "header"
+    required: false
+    type: "integer"
+    description: "The page number to retrieve. Default is 1."
+    example: 1
+  - name: "X-Per-Page"
+    in: "header"
+    required: false
+    type: "integer"
+    description: "The number of logs per page. Default is 10."
+    example: 10
 responses:
   200:
     description: "Logs retrieved successfully"
@@ -46,6 +58,21 @@ responses:
                       username:
                         type: string
                         example: "user1"
+                pagination:
+                  type: object
+                  properties:
+                    page:
+                      type: integer
+                      example: 1
+                    per_page:
+                      type: integer
+                      example: 10
+                    total:
+                      type: integer
+                      example: 100
+                    pages:
+                      type: integer
+                      example: 10
   400:
     description: "Invalid or missing admin key"
     content:


### PR DESCRIPTION
- Updated `get_logs` endpoint in `app.py` to include pagination using `page` and `per_page` headers.
  - Default values: `page=1`, `per_page=10`.
  - Returned pagination metadata including `page`, `per_page`, `total`, and `pages`.
  - Added exception handling to ensure error response on failure.
- Modified Swagger specification (`logs_get.yaml`) to document pagination headers and response structure.
  - Added `X-Page` and `X-Per-Page` headers to request parameters.
  - Enhanced response schema to include pagination metadata.