### PR TITLE
feat(logs): add admin log type listing and log type filter in logs retrieval

### DIFF
--- a/swagger_specs/list_log_types.yaml
+++ b/swagger_specs/list_log_types.yaml
@@ -1,0 +1,43 @@
+tags:
+  - "admin"
+summary: "List all available log types"
+description: "This endpoint allows admins to list all predefined log types in the system."
+parameters:
+  - name: "admin-key"
+    in: "header"
+    required: true
+    schema:
+      type: string
+    description: "Admin key for authentication"
+responses:
+  200:
+    description: "Log types listed successfully."
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            status:
+              type: string
+              example: "OK"
+            message:
+              type: string
+              example: "Log types listed."
+            data:
+              type: array
+              items:
+                type: string
+              example: ["SYSTEM_STARTUP", "SYSTEM_SHUTDOWN", "ERROR_API"]
+  400:
+    description: "Invalid or missing admin key."
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            status:
+              type: string
+              example: "NOK"
+            message:
+              type: string
+              example: "Invalid or missing admin key"

--- a/swagger_specs/logs_get.yaml
+++ b/swagger_specs/logs_get.yaml
@@ -20,6 +20,12 @@ parameters:
     type: "integer"
     description: "The number of logs per page. Default is 10."
     example: 10
+  - name: "X-Log-Type"
+    in: "header"
+    required: false
+    type: "string"
+    description: "The type of logs. Default is SYSTEM_STARTUP."
+    example: "SYSTEM_STARTUP"
 responses:
   200:
     description: "Logs retrieved successfully"


### PR DESCRIPTION
### Summary
- Introduced a new admin endpoint `/admin/log-type/list` to retrieve all predefined log types.
  - Requires `admin-key` for authentication.
  - Logs an event with the `ADMIN_LOG_TYPE_LIST_VIEWED` type when accessed.
- Updated `get_logs` to support filtering logs by type via the `X-Log-Type` header.
  - Default log type is set to `SYSTEM_STARTUP`.
- Added Swagger specification files:
  - `list_log_types.yaml` for the new endpoint.
  - Updated `logs_get.yaml` to include `X-Log-Type` parameter.

### Additional Changes
- Extended `LogTypeEnum` with `ADMIN_LOG_TYPE_LIST_VIEWED`.